### PR TITLE
Quoted target support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,16 @@ module.exports = function(grunt) {
           'tmp/bar.html': 'test/fixtures/index.html',
         }
       },
+      'single-quoted-literal-target': {
+        files: {
+          'tmp/single-quoted-literal-target.html': 'test/fixtures/index.html',
+        }
+      },
+      'double-quoted-literal-target': {
+        files: {
+          'tmp/double-quoted-literal-target.html': 'test/fixtures/index.html',
+        }
+      },
       release: {
         options: {
           curlyTags: {

--- a/tasks/targethtml.js
+++ b/tasks/targethtml.js
@@ -24,6 +24,8 @@ function conditionalParser (target, expression) {
       return !conditionalParser(target, expression.argument);
     case 'Identifier':
       return target===expression.name;
+    case 'Literal':
+      return target===expression.value;
     default :
       throw new Error('Syntax not supported');
   }

--- a/tasks/targethtml.js
+++ b/tasks/targethtml.js
@@ -14,12 +14,12 @@ function conditionalParser (target, expression) {
   switch(expression.type) {
     case 'LogicalExpression':
       if (expression.operator !== '||') { // we only compare one variable so && is useless
-        throw new Error('Syntax not supported');
+        throw new Error('Syntax not supported - \'||\' is the only supported binary logical operator');
       }
       return conditionalParser(target, expression.left) || conditionalParser(target, expression.right);
     case 'UnaryExpression':
       if (expression.operator !== '!') {
-        throw new Error('Syntax not supported');
+        throw new Error('Syntax not supported - \'!\' is the only supported unary operator');
       }
       return !conditionalParser(target, expression.argument);
     case 'Identifier':
@@ -27,7 +27,7 @@ function conditionalParser (target, expression) {
     case 'Literal':
       return target===expression.value;
     default :
-      throw new Error('Syntax not supported');
+      throw new Error('Syntax not supported - only certain logical operators and strings allowed in target expression.');
   }
 }
 

--- a/test/expected/bar.html
+++ b/test/expected/bar.html
@@ -28,3 +28,28 @@
 
 
 
+
+
+
+
+
+
+
+  <link rel="stylesheet" href="not_single-quoted-literal-target.css">
+
+
+
+  <link rel="stylesheet" href="not_single-quoted-literal-target_and_not_foo.css">
+
+
+
+
+
+
+
+  <link rel="stylesheet" href="not_double-quoted-literal-target.css">
+
+
+
+  <link rel="stylesheet" href="not_double-quoted-literal-target_and_not_foo.css">
+

--- a/test/expected/dev.html
+++ b/test/expected/dev.html
@@ -35,3 +35,28 @@
 
 
   <link rel="stylesheet" href="not_bar_and_not_foo.css">
+
+
+
+
+
+
+
+  <link rel="stylesheet" href="not_single-quoted-literal-target.css">
+
+
+
+  <link rel="stylesheet" href="not_single-quoted-literal-target_and_not_foo.css">
+
+
+
+
+
+
+
+  <link rel="stylesheet" href="not_double-quoted-literal-target.css">
+
+
+
+  <link rel="stylesheet" href="not_double-quoted-literal-target_and_not_foo.css">
+

--- a/test/expected/dist.html
+++ b/test/expected/dist.html
@@ -32,3 +32,28 @@
 
 
   <link rel="stylesheet" href="not_bar_and_not_foo.css">
+
+
+
+
+
+
+
+  <link rel="stylesheet" href="not_single-quoted-literal-target.css">
+
+
+
+  <link rel="stylesheet" href="not_single-quoted-literal-target_and_not_foo.css">
+
+
+
+
+
+
+
+  <link rel="stylesheet" href="not_double-quoted-literal-target.css">
+
+
+
+  <link rel="stylesheet" href="not_double-quoted-literal-target_and_not_foo.css">
+

--- a/test/expected/double-quoted-literal-target.html
+++ b/test/expected/double-quoted-literal-target.html
@@ -11,11 +11,7 @@
 
 
 
-  <link rel="stylesheet" href="release.css?001">
 
-
-
-  <script src="release.js?002"></script>
 
 
 
@@ -47,13 +43,13 @@
 
 
 
+  <link rel="stylesheet" href="double-quoted-literal-target.css">
+
+
+
+  <link rel="stylesheet" href="double-quoted-literal-target_or_foo.css">
 
 
 
 
-  <link rel="stylesheet" href="not_double-quoted-literal-target.css">
-
-
-
-  <link rel="stylesheet" href="not_double-quoted-literal-target_and_not_foo.css">
 

--- a/test/expected/foo.html
+++ b/test/expected/foo.html
@@ -30,3 +30,28 @@
   <link rel="stylesheet" href="not_bar.css">
 
 
+
+
+
+
+
+  <link rel="stylesheet" href="single-quoted-literal-target_or_foo.css">
+
+
+
+  <link rel="stylesheet" href="not_single-quoted-literal-target.css">
+
+
+
+
+
+
+
+  <link rel="stylesheet" href="double-quoted-literal-target_or_foo.css">
+
+
+
+  <link rel="stylesheet" href="not_double-quoted-literal-target.css">
+
+
+

--- a/test/expected/single-quoted-literal-target.html
+++ b/test/expected/single-quoted-literal-target.html
@@ -11,11 +11,7 @@
 
 
 
-  <link rel="stylesheet" href="release.css?001">
 
-
-
-  <script src="release.js?002"></script>
 
 
 
@@ -35,15 +31,15 @@
 
 
 
+  <link rel="stylesheet" href="single-quoted-literal-target.css">
+
+
+
+  <link rel="stylesheet" href="single-quoted-literal-target_or_foo.css">
 
 
 
 
-  <link rel="stylesheet" href="not_single-quoted-literal-target.css">
-
-
-
-  <link rel="stylesheet" href="not_single-quoted-literal-target_and_not_foo.css">
 
 
 

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -50,3 +50,35 @@
 <!--(if target !(bar || foo))><!-->
   <link rel="stylesheet" href="not_bar_and_not_foo.css">
 <!--<!(endif)-->
+
+<!--(if target 'single-quoted-literal-target')><!-->
+  <link rel="stylesheet" href="single-quoted-literal-target.css">
+<!--<!(endif)-->
+
+<!--(if target 'single-quoted-literal-target' || foo)><!-->
+  <link rel="stylesheet" href="single-quoted-literal-target_or_foo.css">
+<!--<!(endif)-->
+
+<!--(if target !'single-quoted-literal-target')><!-->
+  <link rel="stylesheet" href="not_single-quoted-literal-target.css">
+<!--<!(endif)-->
+
+<!--(if target !('single-quoted-literal-target' || foo))><!-->
+  <link rel="stylesheet" href="not_single-quoted-literal-target_and_not_foo.css">
+<!--<!(endif)-->
+
+<!--(if target "double-quoted-literal-target")><!-->
+  <link rel="stylesheet" href="double-quoted-literal-target.css">
+<!--<!(endif)-->
+
+<!--(if target "double-quoted-literal-target" || foo)><!-->
+  <link rel="stylesheet" href="double-quoted-literal-target_or_foo.css">
+<!--<!(endif)-->
+
+<!--(if target !"double-quoted-literal-target")><!-->
+  <link rel="stylesheet" href="not_double-quoted-literal-target.css">
+<!--<!(endif)-->
+
+<!--(if target !("double-quoted-literal-target" || foo))><!-->
+  <link rel="stylesheet" href="not_double-quoted-literal-target_and_not_foo.css">
+<!--<!(endif)-->

--- a/test/targethtml_test.js
+++ b/test/targethtml_test.js
@@ -6,7 +6,7 @@ exports.targethtml = function(test){
 
   var expected, result;
 
-  test.expect(6);
+  test.expect(8);
 
   expected = grunt.file.read('test/expected/dev.html');
   result = grunt.file.read('tmp/dev.html');
@@ -29,6 +29,14 @@ exports.targethtml = function(test){
   expected = grunt.file.read('test/expected/bar.html');
   result = grunt.file.read('tmp/bar.html');
   test.equal(result, expected, 'should process :bar target');
+
+  expected = grunt.file.read('test/expected/single-quoted-literal-target.html');
+  result = grunt.file.read('tmp/single-quoted-literal-target.html');
+  test.equal(result, expected, 'should process :\'single-quoted-literal-target\' target');
+
+  expected = grunt.file.read('test/expected/double-quoted-literal-target.html');
+  result = grunt.file.read('tmp/double-quoted-literal-target.html');
+  test.equal(result, expected, 'should process :"double-quoted-literal-target" target');
 
   test.done();
 


### PR DESCRIPTION
Grunt will accept quoted target names, which is useful if you want hyphens in target names, for example:

``` javascript
targethtml: {
  'dev-test': {
    files: {
      'tmp/dev.html': 'test/fixtures/index.html'
    }
  }
}
```

This pull request is to add support for the _literal_ expression.type to the _conditionalParser_ function, in order to make quoted target names work again. It stopped working after the introduction of the conditional support/esprima.

This pull request includes the change itself (which is quite small), plus a few tests and more verbose error messages that helped during my troubleshooting.

I've been using this for a while now and it works for me.
